### PR TITLE
fix: make expenses table horizontally scrollable on mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -144,7 +144,19 @@
                             <input type="number" id="e-amount" required placeholder="Amount" class="p-2 border dark:bg-slate-700 rounded">
                             <button type="submit" class="bg-red-600 text-white font-bold py-2 rounded md:col-span-4 shadow-md">Add Expense</button>
                         </form>
-                        <div class="bg-white dark:bg-slate-800 rounded border overflow-hidden"><table class="w-full text-sm"><thead class="bg-slate-50 dark:bg-slate-700 border-b dark:border-slate-600"><tr><th class="p-3 text-left font-bold text-slate-500">Date</th><th class="p-3 text-left font-bold text-slate-500">Description</th><th class="p-3 text-left font-bold text-slate-500">Amount</th><th class="p-3 text-right font-bold text-slate-500">Action</th></tr></thead><tbody id="expense-log-table" class="divide-y dark:divide-slate-700"></tbody></table></div>
+                        <div class="bg-white dark:bg-slate-800 rounded border overflow-x-auto shadow-sm">
+                            <table class="w-full text-sm min-w-[600px]">
+                                <thead class="bg-slate-50 dark:bg-slate-700 border-b dark:border-slate-600">
+                                    <tr>
+                                        <th class="p-3 text-left font-bold text-slate-500">Date</th>
+                                        <th class="p-3 text-left font-bold text-slate-500">Description</th>
+                                        <th class="p-3 text-left font-bold text-slate-500">Amount</th>
+                                        <th class="p-3 text-right font-bold text-slate-500">Action</th>
+                                    </tr>
+                                </thead>
+                                <tbody id="expense-log-table" class="divide-y dark:divide-slate-700"></tbody>
+                            </table>
+                        </div>
                     </div>
                 </div>
             </div>

--- a/js/ui.js
+++ b/js/ui.js
@@ -119,8 +119,9 @@ export const renderExpenses = (e) => {
     body.innerHTML = '';
     e.sort((a,b) => new Date(b.date) - new Date(a.date)).forEach(x => {
         const row = body.insertRow();
-        row.innerHTML = `<td class="p-3 dark:text-slate-300">${x.date}</td><td class="p-3 dark:text-slate-200">${x.description}</td><td class="p-3 font-bold dark:text-white">${formatCurrency(x.amount)}</td>
-        <td class="p-3 text-right"><button data-id="${x.id}" class="text-red-500 text-[10px] font-bold delete-expense-btn uppercase">Delete</button></td>`;
+        // Added whitespace-nowrap to cells to ensure horizontal scroll triggers correctly on mobile
+        row.innerHTML = `<td class="p-3 dark:text-slate-300 whitespace-nowrap">${x.date}</td><td class="p-3 dark:text-slate-200 whitespace-nowrap">${x.description}</td><td class="p-3 font-bold dark:text-white whitespace-nowrap">${formatCurrency(x.amount)}</td>
+        <td class="p-3 text-right whitespace-nowrap"><button data-id="${x.id}" class="text-red-500 text-[10px] font-bold delete-expense-btn uppercase">Delete</button></td>`;
     });
 };
 


### PR DESCRIPTION
Wrapped the expenses table in an overflow-x-auto container to fix accessibility on mobile devices.

Added whitespace-nowrap to table cells in js/ui.js to ensure the table doesn't collapse and triggers the horizontal scroll.

Fixes #4 