### PR TITLE
security: rotate leaked api key and apply domain restrictions

### DIFF
--- a/js/config.js
+++ b/js/config.js
@@ -3,7 +3,7 @@ import { getAuth } from "https://www.gstatic.com/firebasejs/11.6.1/firebase-auth
 import { getFirestore } from "https://www.gstatic.com/firebasejs/11.6.1/firebase-firestore.js";
 
 const firebaseConfig = {
-    apiKey: "AIzaSyCqzL_cPFd2bDsuV4jhrEv2wxifZsXLVIw",
+    apiKey: "AIzaSyC-ndIaiKx734_YbuL6-W8j9F3Jw2uX7Qw",
     authDomain: "society-expense-tracker.firebaseapp.com",
     projectId: "society-expense-tracker",
     storageBucket: "society-expense-tracker.appspot.com",


### PR DESCRIPTION
Problem: GitHub Secret Scanning detected a publicly exposed API key in js/config.js.

Solution:

Replaced the compromised key with a new restricted API key in js/config.js.

Applied HTTP Referrer restrictions for Vercel deployment, Firebase domains, and localhost.

Limited API scopes to only Cloud Firestore, Identity Toolkit, and Token Service.

Impact: Resolves the security vulnerability flagged by GitHub.

Fixes #6 