### PR TITLE
fix: make payment logs table horizontally scrollable on mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -435,26 +435,15 @@
                   Log Payment
                 </button>
               </form>
-              <div
-                class="bg-white dark:bg-slate-800 rounded shadow overflow-hidden"
-              >
-                <table class="w-full text-sm">
-                  <thead
-                    class="bg-slate-50 dark:bg-slate-700 border-b dark:border-slate-600"
-                  >
+              <!-- THE UNIVERSAL SCROLLABLE WRAPPER -->
+              <div class="bg-white dark:bg-slate-800 rounded shadow overflow-x-auto w-full">
+                <table class="w-full text-sm min-w-[650px]">
+                  <thead class="bg-slate-50 dark:bg-slate-700 border-b dark:border-slate-600">
                     <tr>
-                      <th class="p-3 text-left font-bold text-slate-500">
-                        Date
-                      </th>
-                      <th class="p-3 text-left font-bold text-slate-500">
-                        Flat & Owner
-                      </th>
-                      <th class="p-3 text-left font-bold text-slate-500">
-                        Amount
-                      </th>
-                      <th class="p-3 text-right font-bold text-slate-500">
-                        Action
-                      </th>
+                      <th class="p-3 text-left font-bold text-slate-500 whitespace-nowrap">Date</th>
+                      <th class="p-3 text-left font-bold text-slate-500 whitespace-nowrap">Flat & Owner</th>
+                      <th class="p-3 text-left font-bold text-slate-500 whitespace-nowrap">Amount</th>
+                      <th class="p-3 text-right font-bold text-slate-500 whitespace-nowrap">Action</th>
                     </tr>
                   </thead>
                   <tbody

--- a/js/ui.js
+++ b/js/ui.js
@@ -155,11 +155,12 @@ export const renderCollections = (c) => {
     body.innerHTML = '';
     c.sort((a,b) => new Date(b.date) - new Date(a.date)).forEach(x => {
         const row = body.insertRow();
+        // Added whitespace-nowrap to all td elements to enforce universal horizontal scrolling
         row.innerHTML = `
-            <td class="p-3 dark:text-slate-300">${formatDateForDisplay(x.date)}</td>
-            <td class="p-3 dark:text-slate-200">${x.flatNo} - ${x.ownerName}</td>
-            <td class="p-3 font-bold text-green-600">${formatCurrency(x.amount)}</td>
-            <td class="p-3 text-right flex justify-end items-center gap-3">
+            <td class="p-3 dark:text-slate-300 whitespace-nowrap">${formatDateForDisplay(x.date)}</td>
+            <td class="p-3 dark:text-slate-200 whitespace-nowrap">${x.flatNo} - ${x.ownerName}</td>
+            <td class="p-3 font-bold text-green-600 whitespace-nowrap">${formatCurrency(x.amount)}</td>
+            <td class="p-3 text-right flex justify-end items-center gap-3 whitespace-nowrap">
                 <button data-id="${x.id}" 
                         data-name="${x.ownerName}" 
                         data-flat="${x.flatNo}" 


### PR DESCRIPTION
## Overview
This PR fixes the mobile UI issue where the Payment Logs table was getting cut off on smaller screens. Previously, the Action/Delete buttons were hidden and inaccessible because the table was restricted by its container. 

We have introduced a **Universal Scrollable Table Formula** that forces the table to scroll horizontally on small devices without breaking the overall dashboard layout.

## 🛠️ Technical Changes & Explanation

### 1. Structure Updates (`index.html`)
* **Removed `overflow-hidden`:** The previous wrapper was actively cutting off (hiding) any content that exceeded the screen width.
* **Added `overflow-x-auto` & `w-full`:** We wrapped the table in a new container that tells the browser to enable swipe-to-scroll functionality *only* when the content overflows horizontally.
* **Added `min-w-[650px]`:** HTML tables naturally try to shrink to fit the screen. By enforcing a minimum width, we force the table to break out of small mobile viewports, intentionally triggering the horizontal scroll we added above.

### 2. Data Rendering Updates (`js/ui.js`)
* **Added `whitespace-nowrap` to cells:** By default, browsers wrap text (break it into multiple lines) to make it fit inside a shrinking column. By applying `whitespace-nowrap` to our dynamically generated `<td>` and `<th>` elements, we instruct the browser to keep the text in a single horizontal line. 
* **The Result:** Because the text refuses to break, the columns refuse to shrink. This works perfectly with our `min-w-[650px]` rule to ensure the table remains wide and cleanly scrollable.

## 📱 Testing Done
- [x] Verified on Desktop view (table takes full width normally).
- [x] Verified on Mobile/Responsive view (table smoothly scrolls left/right to reveal amounts and action buttons).

Closes #40 