### PR TITLE
fix: sort payment logs strictly by exact creation timestamp

### DIFF
--- a/js/ui.js
+++ b/js/ui.js
@@ -153,9 +153,24 @@ export const renderExpenses = (e) => {
 export const renderCollections = (c) => {
     const body = document.getElementById('collection-log-table'); if(!body) return;
     body.innerHTML = '';
-    c.sort((a,b) => new Date(b.date) - new Date(a.date)).forEach(x => {
+    
+    // Sort by calendar date first, then use the exact creation timestamp as a tie-breaker. 
+    c.sort((a, b) => {
+        // 1. Compare the calendar dates
+        const dateA = new Date(a.date).getTime();
+        const dateB = new Date(b.date).getTime();
+        
+        if (dateA !== dateB) {
+            return dateB - dateA; // Display the most recent date first.
+        }
+        
+        // 2. If the dates are the same, retrieve the exact order using the Firebase timestamp.
+        const timeA = a.createdAt ? (typeof a.createdAt.toMillis === 'function' ? a.createdAt.toMillis() : new Date(a.createdAt).getTime()) : 0;
+        const timeB = b.createdAt ? (typeof b.createdAt.toMillis === 'function' ? b.createdAt.toMillis() : new Date(b.createdAt).getTime()) : 0;
+        
+        return timeB - timeA; // Show the most recently created record first.
+    }).forEach(x => {
         const row = body.insertRow();
-        // Added whitespace-nowrap to all td elements to enforce universal horizontal scrolling
         row.innerHTML = `
             <td class="p-3 dark:text-slate-300 whitespace-nowrap">${formatDateForDisplay(x.date)}</td>
             <td class="p-3 dark:text-slate-200 whitespace-nowrap">${x.flatNo} - ${x.ownerName}</td>


### PR DESCRIPTION
## 🐛 The Problem (Context)
Currently, when the society admins look at the Payments Log, transactions from the same day appear in a random, jumbled order. 
* **Why?** The old code only sorted the array using the calendar date (`YYYY-MM-DD`). If 5 residents paid on the exact same date (e.g., `2026-05-20`), the sorting logic treated them as a "tie" and placed them randomly, making it impossible to audit which payment came first.

## 🛠️ The Fix (What Changed)
We updated the `renderCollections` sorting logic inside `js/ui.js`. We replaced the single-level date sort with a **Two-Tier Sorting Algorithm** that acts as a tie-breaker.

### 🧠 The Logic Explained (For Future Reference)
The new `c.sort()` logic now works in two steps:
1. **Primary Sort (Calendar Date):** The code first compares the date strings. If the dates are different (e.g., May 20 vs May 19), it sorts them normally (Newest First).
2. **Secondary Sort (The Tie-Breaker):** If the calendar dates are exactly the same, the code now fetches the Firebase `createdAt` property (which records the exact millisecond the entry was created). It uses this exact timestamp to sort the tied entries.

## 🌍 Impact
- **No Database Migration Needed:** Because Firebase was already saving the `createdAt` timestamp, this UI-level fix automatically applies to all **historical data (existing sheets)** as well as **future sheets**.
- Admins will now see a 100% strict chronological sequence (Latest payment on top), ending the confusion around same-day collections.

Closes #42 