### PR TITLE
feat: add persistent smart receipt share state

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -14,6 +14,7 @@ import {
   getDocs,
   doc,
   getDoc,
+  updateDoc,
 } from "https://www.gstatic.com/firebasejs/11.6.1/firebase-firestore.js";
 
 let state = {
@@ -483,7 +484,7 @@ if (t.closest(".share-receipt-btn")) {
     const flat = btn.dataset.flat;
     const amount = UI.formatCurrency(btn.dataset.amount);
 
-    // Database se resident ka phone number nikalen
+    // Extract the resident's phone number from the local state
     const resident = state.residents.find(r => r.flatNo === flat);
     const phone = resident ? resident.phone : "";
 
@@ -491,7 +492,7 @@ if (t.closest(".share-receipt-btn")) {
     const verificationLink = `${cleanUrl}?receiptId=${id}`;
     
     // 🌟 SMART MONTH LOGIC 🌟
-    // Pehle state se mahine ka naam dhoondhne ki koshish karte hain
+    // Try to fetch the current month name from the state first
     let currentMonth = "Maintenance";
     if (typeof state !== 'undefined') {
         if (state.currentSheetName) currentMonth = state.currentSheetName;
@@ -499,26 +500,51 @@ if (t.closest(".share-receipt-btn")) {
         else if (state.sheetName) currentMonth = state.sheetName;
     }
     
-    // Agar state mein nahi mila, toh aaj ki date se mahina aur saal nikal lo (e.g., "May 2026")
+    // If it is not found in the state, generate it from today's date (e.g., "May 2026")
     if (currentMonth === "Maintenance") {
         const d = new Date();
         currentMonth = d.toLocaleString('en-IN', { month: 'long' }) + " " + d.getFullYear();
     }
 
-    // Message ko properly encode karna zaroori hai
+    // Message must be properly encoded
     const message = encodeURIComponent(`*Dinkar Elite Maintenance Receipt - ${currentMonth}*
 
 Hello ${name} (Flat ${flat}), your maintenance payment of ${amount} for ${currentMonth} has been successfully recorded.
 
 View Receipt: ${verificationLink}`);
-    // Agar phone number hai toh direct chat, nahi toh general share
+    
+    // Direct chat if phone number exists, otherwise general share
     let waBase = "https://wa.me/";
     if (phone) {
         const cleanPhone = phone.replace(/\D/g, '');
         waBase += (cleanPhone.length === 10 ? "91" + cleanPhone : cleanPhone);
     }
 
+    // Open WhatsApp in a new tab
     window.open(`${waBase}?text=${message}`, "_blank");
+
+    // 🌟 NEW LOGIC: SMART BUTTON & DATABASE UPDATE 🌟
+    
+
+    //  Update the Local State
+    const collectionIndex = state.collections.findIndex(c => c.id === id);
+    if (collectionIndex > -1) {
+        state.collections[collectionIndex].receiptShared = true;
+        UI.renderCollections(state.collections);
+    }
+
+    //  Update Firestore Database
+    // Using the flat structure confirmed from your database screenshot
+    const docRef = doc(db, "maintenance", id);
+    
+    updateDoc(docRef, {
+        receiptShared: true
+    }).then(() => {
+        console.log(`Receipt state for ${id} saved as shared.`);
+    }).catch((error) => {
+        console.error("Error updating receipt state:", error);
+    });
+
     return;
 }
 

--- a/js/app.js
+++ b/js/app.js
@@ -537,13 +537,24 @@ View Receipt: ${verificationLink}`);
     // Using the flat structure confirmed from your database screenshot
     const docRef = doc(db, "maintenance", id);
     
-    updateDoc(docRef, {
+    try {
+    await updateDoc(docRef, {
         receiptShared: true
-    }).then(() => {
-        console.log(`Receipt state for ${id} saved as shared.`);
-    }).catch((error) => {
-        console.error("Error updating receipt state:", error);
     });
+
+    console.log(`Receipt state for ${id} saved as shared.`);
+
+    } catch (error) {
+    console.error("Error updating receipt state:", error);
+
+    // Roll back local state
+    if (collectionIndex > -1) {
+        state.collections[collectionIndex].receiptShared = false;
+        UI.renderCollections(state.collections);
+    }
+
+    UI.showToast("Failed to save receipt status.", true);
+    }
 
     return;
 }

--- a/js/ui.js
+++ b/js/ui.js
@@ -171,6 +171,16 @@ export const renderCollections = (c) => {
         return timeB - timeA; // Show the most recently created record first.
     }).forEach(x => {
         const row = body.insertRow();
+
+        // Check if the receipt has already been shared from the database flag
+        const isShared = x.receiptShared === true;
+        
+        const btnClass = isShared 
+            ? "text-slate-500 font-bold text-[10px] share-receipt-btn uppercase border border-slate-300 dark:border-slate-600 px-2 py-1 rounded bg-slate-100 dark:bg-slate-700 hover:bg-slate-200 dark:hover:bg-slate-600 transition-all"
+            : "text-teal-600 font-bold text-[10px] share-receipt-btn uppercase border border-teal-600 px-2 py-1 rounded hover:bg-teal-600 hover:text-white transition-all";
+            
+        const btnText = isShared ? "Shared ✅" : "Share";
+        
         row.innerHTML = `
             <td class="p-3 dark:text-slate-300 whitespace-nowrap">${formatDateForDisplay(x.date)}</td>
             <td class="p-3 dark:text-slate-200 whitespace-nowrap">${x.flatNo} - ${x.ownerName}</td>
@@ -180,8 +190,8 @@ export const renderCollections = (c) => {
                         data-name="${x.ownerName}" 
                         data-flat="${x.flatNo}" 
                         data-amount="${x.amount}" 
-                        class="text-teal-600 font-bold text-[10px] share-receipt-btn uppercase border border-teal-600 px-2 py-1 rounded hover:bg-teal-600 hover:text-white transition-all">
-                    Share
+                        class="${btnClass}">
+                        ${btnText}
                 </button>
                 <button data-id="${x.id}" class="text-red-500 text-[10px] font-bold delete-collection-btn uppercase">Delete</button>
             </td>`;


### PR DESCRIPTION
## Summary

Introduces a persistent smart receipt sharing experience for the maintenance payment log.

The receipt share button now reflects whether a receipt has already been shared, helping prevent duplicate shares and making it easy to identify pending receipts.

## Changes

- Render the receipt share button based on the persisted `receiptShared` state.
- Remove direct DOM manipulation and derive button appearance from application state.
- Persist receipt share status in Firestore after initiating WhatsApp sharing.
- Roll back the local UI state if Firestore persistence fails.
- Show an error toast when the share status cannot be saved.

## Testing

- Verified "Share" is shown for receipts without a shared state.
- Verified "Shared ✅" is shown for persisted shared receipts.
- Verified state persists after page refresh.
- Verified rollback occurs when Firestore update fails.

Closes #44 